### PR TITLE
Add GroundingDINO + SAM2 few-shot auto-labeling pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,122 @@
-# autodetector
+# GroundingDINO + SAM2 defect auto-labeling
+
+This repository packages a lightweight pipeline that combines **GroundingDINO** and **SAM2**
+for automatic annotation bootstrapping / pseudo-label generation. The goal is to turn a
+small set of reference defect examples (few-shot) into usable annotations for the rest of
+an unlabeled dataset.
+
+## Key features
+
+* ⚙️ One-line interface via `AutoLabeler` class or CLI.
+* 🗂️ Generates per-instance folders with mask/box overlays, crops and JSON metadata.
+* 🧠 Optional CLIP-based few-shot filtering using a tiny support manifest of positive crops.
+* 🧾 Emits `summary.json` + per-image manifests for downstream dataset conversion.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121  # adapt for your CUDA
+pip install opencv-python pillow groundingdino-py sam2 open-clip-torch huggingface_hub
+```
+
+> **Note**: install the CUDA-enabled PyTorch build that matches your driver. On CPU-only
+> machines use the default PyPI wheels instead.
+
+The pipeline downloads all checkpoints on first use into `~/.autodetector` (or the custom
+cache directory you pass).
+
+## Few-shot support manifest
+
+To enable CLIP-based filtering, prepare a JSON list describing a handful of positive
+examples. Each entry should contain a path to the original support image and the bounding
+box of a defect crop in **absolute pixel coordinates**:
+
+```json
+[
+  {
+    "image": "support/image_001.jpg",
+    "bbox": [120, 45, 260, 220],
+    "label": "crack"
+  },
+  {
+    "image": "support/image_017.jpg",
+    "bbox": [80, 66, 150, 145],
+    "label": "corrosion"
+  }
+]
+```
+
+Only a few entries (4-10) are typically needed. The CLIP filter keeps detections whose
+cosine similarity with the support embeddings exceeds `clip_threshold` (default `0.22`).
+You can tune this value based on validation results.
+
+## Python usage
+
+```python
+from pathlib import Path
+from autodetector import AutoLabeler, AutoLabelerConfig
+
+config = AutoLabelerConfig(
+    prompt="defect . damage . crack .",
+    support_manifest=Path("support_manifest.json"),
+    box_threshold=0.28,
+    text_threshold=0.22,
+    min_area_ratio=0.0004,
+    top_k=15,
+)
+labeler = AutoLabeler(config)
+
+instances_per_image = labeler.process_directory(
+    image_dir=Path("data/unlabeled"),
+    output_dir=Path("outputs/autolabel"),
+)
+```
+
+After running you will obtain the following structure:
+
+```
+outputs/autolabel/
+├── IMG_0001/
+│   ├── instance_00/
+│   │   ├── bbox.png
+│   │   ├── mask.png
+│   │   ├── overlay.png
+│   │   └── report.json
+│   ├── instance_01/
+│   └── manifest.json
+├── IMG_0002/
+└── summary.json
+```
+
+Each `report.json` contains the model scores, CLIP similarity (if available) and paths to
+other assets to ease downstream filtering. `summary.json` is a convenient collection of
+per-image detections.
+
+## Command line interface
+
+```bash
+python -m autodetector.cli \
+  --images data/unlabeled \
+  --output outputs/autolabel \
+  --prompt "defect . crack . corrosion ." \
+  --support-manifest support_manifest.json \
+  --box-threshold 0.3 \
+  --text-threshold 0.25 \
+  --min-area-ratio 0.0004 \
+  --top-k 20
+```
+
+Use `--multimask` to let SAM2 return multiple masks per detection (the pipeline will pick
+the best IoU prediction). When running on CPU or low-memory GPUs consider lowering
+`top_k` and increasing `box_threshold`.
+
+## Next steps
+
+* Review overlays and tweak the thresholds. Increasing `clip_threshold` raises precision.
+* Convert manifests to YOLO/COCO (all metadata is already available in JSON).
+* Mix pseudo-labels with your 420 hand-labeled samples and fine-tune a compact detector
+  such as YOLOv12x or RT-DETR.
+
+Happy auto-labeling!

--- a/autodetector/__init__.py
+++ b/autodetector/__init__.py
@@ -1,0 +1,9 @@
+"""Autodetector package."""
+
+from .pipeline import AutoLabeler, AutoLabelerConfig, AutoLabelInstance
+
+__all__ = [
+    "AutoLabeler",
+    "AutoLabelerConfig",
+    "AutoLabelInstance",
+]

--- a/autodetector/cli.py
+++ b/autodetector/cli.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .pipeline import AutoLabeler, AutoLabelerConfig
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="GroundingDINO + SAM2 auto-labeling pipeline")
+    parser.add_argument("--images", type=Path, required=True, help="Directory with source images")
+    parser.add_argument("--output", type=Path, required=True, help="Directory to store auto-label artifacts")
+    parser.add_argument("--prompt", type=str, default=None, help="GroundingDINO text prompt")
+    parser.add_argument("--box-threshold", type=float, default=None, help="GroundingDINO box threshold")
+    parser.add_argument("--text-threshold", type=float, default=None, help="GroundingDINO text threshold")
+    parser.add_argument("--top-k", type=int, default=None, help="Keep at most K detections per image")
+    parser.add_argument("--min-area-ratio", type=float, default=None, help="Filter masks smaller than this ratio")
+    parser.add_argument("--multimask", action="store_true", help="Enable SAM2 multi-mask output")
+    parser.add_argument("--device", type=str, default=None, help="Force device (cpu/cuda)")
+    parser.add_argument(
+        "--models-dir", type=Path, default=None, help="Directory to cache checkpoints (default ~/.autodetector)"
+    )
+    parser.add_argument(
+        "--support-manifest",
+        type=Path,
+        default=None,
+        help="JSON manifest with support crops for few-shot CLIP filtering",
+    )
+    parser.add_argument("--clip-threshold", type=float, default=None, help="Reject predictions below this CLIP score")
+    parser.add_argument("--support-limit", type=int, default=None, help="Limit number of support crops to load")
+    parser.add_argument(
+        "--clip-model",
+        type=str,
+        default=None,
+        help="open_clip model name for few-shot filtering (default ViT-B-32)",
+    )
+    parser.add_argument(
+        "--clip-pretrained",
+        type=str,
+        default=None,
+        help="open_clip pretrained weights tag (default laion2b_s34b_b79k)",
+    )
+    parser.add_argument(
+        "--overlay-alpha",
+        type=float,
+        default=None,
+        help="Overlay alpha when drawing masks (0-1)",
+    )
+    return parser
+
+
+def parse_config(args: argparse.Namespace) -> AutoLabelerConfig:
+    config = AutoLabelerConfig()
+    if args.prompt is not None:
+        config.prompt = args.prompt
+    if args.box_threshold is not None:
+        config.box_threshold = args.box_threshold
+    if args.text_threshold is not None:
+        config.text_threshold = args.text_threshold
+    if args.top_k is not None:
+        config.top_k = args.top_k
+    if args.min_area_ratio is not None:
+        config.min_area_ratio = args.min_area_ratio
+    if args.multimask:
+        config.multimask_output = True
+    if args.device is not None:
+        config.device = args.device
+    if args.models_dir is not None:
+        config.models_dir = args.models_dir
+    if args.support_manifest is not None:
+        config.support_manifest = args.support_manifest
+    if args.clip_threshold is not None:
+        config.clip_threshold = args.clip_threshold
+    if args.support_limit is not None:
+        config.support_limit = args.support_limit
+    if args.clip_model is not None:
+        config.clip_model = args.clip_model
+    if args.clip_pretrained is not None:
+        config.clip_pretrained = args.clip_pretrained
+    if args.overlay_alpha is not None:
+        config.overlay_alpha = args.overlay_alpha
+    return config
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    config = parse_config(args)
+    labeler = AutoLabeler(config)
+
+    results = labeler.process_directory(args.images, args.output)
+
+    summary = []
+    image_paths = sorted(
+        p for p in args.images.expanduser().resolve().iterdir() if p.is_file()
+    )
+    for image_path, instances in zip(image_paths, results):
+        summary.append(
+            {
+                "image": str(image_path),
+                "instances": [
+                    {
+                        "index": instance.index,
+                        "score": instance.score,
+                        "clip_score": instance.clip_score,
+                        "bbox": instance.bbox,
+                        "phrase": instance.phrase,
+                        "area_ratio": instance.area_ratio,
+                        "overlay": str(instance.overlay_path),
+                        "mask": str(instance.mask_path),
+                        "crop": str(instance.crop_path),
+                    }
+                    for instance in instances
+                ],
+            }
+        )
+
+    summary_path = args.output.expanduser().resolve() / "summary.json"
+    with summary_path.open("w", encoding="utf-8") as fp:
+        json.dump(summary, fp, indent=2)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/autodetector/pipeline.py
+++ b/autodetector/pipeline.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import cv2
+import numpy as np
+import torch
+from PIL import Image
+
+from groundingdino.util import box_ops
+from groundingdino.util.inference import load_image, load_model, predict
+from huggingface_hub import hf_hub_download
+
+try:  # Optional dependency; imported lazily when needed
+    import open_clip
+except Exception:  # pragma: no cover - optional dependency error path
+    open_clip = None  # type: ignore
+
+from sam2.build_sam import HF_MODEL_ID_TO_FILENAMES, build_sam2
+from sam2.sam2_image_predictor import SAM2ImagePredictor
+
+GROUNDING_REPO = "ShilongLiu/GroundingDINO"
+GROUNDING_WEIGHTS = "groundingdino_swint_ogc.pth"
+GROUNDING_CONFIG = "GroundingDINO_SwinT_OGC.cfg.py"
+SAM2_REPO = "facebook/sam2-hiera-large"
+
+
+@dataclass
+class AutoLabelerConfig:
+    """Configuration for :class:`AutoLabeler`."""
+
+    prompt: str = "defect . damage . flaw ."
+    box_threshold: float = 0.3
+    text_threshold: float = 0.25
+    top_k: int = 25
+    min_area_ratio: float = 5e-4
+    multimask_output: bool = False
+    device: Optional[str] = None
+    models_dir: Path = Path("~/.autodetector")
+    support_manifest: Optional[Path] = None
+    support_limit: Optional[int] = 16
+    clip_model: str = "ViT-B-32"
+    clip_pretrained: str = "laion2b_s34b_b79k"
+    clip_threshold: float = 0.22
+    overlay_alpha: float = 0.45
+
+    def resolve(self) -> "AutoLabelerConfig":
+        self.models_dir = self.models_dir.expanduser().resolve()
+        if self.support_manifest is not None:
+            self.support_manifest = self.support_manifest.expanduser().resolve()
+        return self
+
+
+@dataclass
+class SupportExample:
+    embedding: torch.Tensor
+    label: str
+
+
+@dataclass
+class AutoLabelInstance:
+    index: int
+    score: float
+    phrase: str
+    bbox: List[int]
+    area_ratio: float
+    overlay_path: Path
+    mask_path: Path
+    crop_path: Path
+    metadata_path: Path
+    clip_score: Optional[float] = None
+
+
+class AutoLabeler:
+    """High-level pipeline that combines GroundingDINO and SAM 2 for pseudo labels."""
+
+    def __init__(self, config: Optional[AutoLabelerConfig] = None) -> None:
+        self.config = (config or AutoLabelerConfig()).resolve()
+        self.device = torch.device(
+            self.config.device or ("cuda" if torch.cuda.is_available() else "cpu")
+        )
+        self.config.models_dir.mkdir(parents=True, exist_ok=True)
+
+        self._dino_model = self._load_groundingdino()
+        self._sam_predictor = self._load_sam2()
+        self._clip_model = None
+        self._clip_preprocess = None
+        self._support_examples: list[SupportExample] = []
+
+        if self.config.support_manifest is not None:
+            self._load_support_embeddings()
+
+    # ------------------------------------------------------------------
+    # Model loading helpers
+    # ------------------------------------------------------------------
+    def _load_groundingdino(self):
+        grounding_dir = self.config.models_dir / "groundingdino"
+        grounding_dir.mkdir(parents=True, exist_ok=True)
+        config_path = hf_hub_download(
+            GROUNDING_REPO, GROUNDING_CONFIG, local_dir=grounding_dir
+        )
+        weights_path = hf_hub_download(
+            GROUNDING_REPO, GROUNDING_WEIGHTS, local_dir=grounding_dir
+        )
+        model = load_model(str(config_path), str(weights_path))
+        model.to(self.device)
+        model.eval()
+        return model
+
+    def _load_sam2(self) -> SAM2ImagePredictor:
+        sam2_dir = self.config.models_dir / "sam2"
+        sam2_dir.mkdir(parents=True, exist_ok=True)
+        config_name, checkpoint_name = HF_MODEL_ID_TO_FILENAMES[SAM2_REPO]
+        checkpoint_path = hf_hub_download(
+            SAM2_REPO, filename=checkpoint_name, local_dir=sam2_dir
+        )
+        sam_model = build_sam2(
+            config_file=config_name, ckpt_path=str(checkpoint_path), device=str(self.device)
+        )
+        return SAM2ImagePredictor(sam_model)
+
+    def _ensure_clip(self) -> None:
+        if self._clip_model is not None:
+            return
+        if open_clip is None:
+            raise RuntimeError(
+                "open_clip is not installed. Install open-clip-torch to enable support filtering."
+            )
+        model, _, preprocess = open_clip.create_model_and_transforms(
+            self.config.clip_model,
+            pretrained=self.config.clip_pretrained,
+            device=self.device,
+        )
+        model.eval()
+        self._clip_model = model
+        self._clip_preprocess = preprocess
+
+    def _load_support_embeddings(self) -> None:
+        self._ensure_clip()
+        assert self._clip_model is not None
+        assert self._clip_preprocess is not None
+
+        manifest_path = self.config.support_manifest
+        if manifest_path is None:
+            return
+        with manifest_path.open("r", encoding="utf-8") as fp:
+            manifest = json.load(fp)
+        if not isinstance(manifest, Iterable):
+            raise ValueError("Support manifest must be a list of entries.")
+
+        examples: list[SupportExample] = []
+        for entry in manifest:
+            image_path = Path(entry["image"]).expanduser().resolve()
+            bbox = entry.get("bbox")
+            label = entry.get("label", "support")
+            if bbox is None or len(bbox) != 4:
+                raise ValueError("Each support entry must contain a bbox with four integers.")
+            with Image.open(image_path) as pil_image:  # type: ignore[arg-type]
+                crop = pil_image.convert("RGB").crop(tuple(bbox))
+            tensor = self._clip_preprocess(crop).unsqueeze(0).to(self.device)
+            with torch.no_grad():
+                embedding = self._clip_model.encode_image(tensor)
+            embedding = torch.nn.functional.normalize(embedding, dim=-1)
+            examples.append(SupportExample(embedding=embedding, label=label))
+            if self.config.support_limit and len(examples) >= self.config.support_limit:
+                break
+        self._support_examples = examples
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def process_directory(
+        self,
+        image_dir: Path,
+        output_dir: Path,
+        image_extensions: Optional[tuple[str, ...]] = (".jpg", ".jpeg", ".png", ".bmp"),
+    ) -> list[list[AutoLabelInstance]]:
+        image_dir = image_dir.expanduser().resolve()
+        output_dir = output_dir.expanduser().resolve()
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        manifest: list[list[AutoLabelInstance]] = []
+        for image_path in sorted(image_dir.iterdir()):
+            if not image_path.is_file():
+                continue
+            if image_extensions and image_path.suffix.lower() not in image_extensions:
+                continue
+            instances = self.process_image(image_path, output_dir / image_path.stem)
+            manifest.append(instances)
+        return manifest
+
+    def process_image(self, image_path: Path, output_dir: Path) -> list[AutoLabelInstance]:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        image_source, image_tensor = load_image(str(image_path))
+        height, width = image_source.shape[:2]
+
+        boxes, logits, phrases = predict(
+            model=self._dino_model,
+            image=image_tensor,
+            caption=self.config.prompt,
+            box_threshold=self.config.box_threshold,
+            text_threshold=self.config.text_threshold,
+            device=self.device,
+        )
+        if boxes.shape[0] == 0:
+            return []
+
+        boxes_xyxy = box_ops.box_cxcywh_to_xyxy(boxes)
+        boxes_xyxy *= torch.tensor([width, height, width, height], device=boxes_xyxy.device)
+        boxes_xyxy = boxes_xyxy.cpu().numpy()
+        logits = logits.sigmoid().cpu().numpy()
+
+        self._sam_predictor.set_image(image_source)
+
+        candidates = []
+        for box_xyxy, logit_vec, phrase in zip(boxes_xyxy, logits, phrases):
+            masks, iou_predictions, _ = self._sam_predictor.predict(
+                box=box_xyxy,
+                multimask_output=self.config.multimask_output,
+                normalize_coords=True,
+            )
+            if self.config.multimask_output and masks.shape[0] > 1:
+                best_idx = int(np.argmax(iou_predictions))
+                mask = masks[best_idx]
+            else:
+                mask = masks[0]
+            mask_bool = mask.astype(bool)
+            area_ratio = float(mask_bool.sum()) / float(height * width)
+            if area_ratio < self.config.min_area_ratio:
+                continue
+            candidates.append((box_xyxy, mask_bool, logit_vec, phrase, area_ratio))
+
+        if not candidates:
+            return []
+
+        instances: list[tuple] = []
+        for idx, (box_xyxy, mask_bool, logit_vec, phrase, area_ratio) in enumerate(candidates):
+            bbox = self._sanitize_bbox(box_xyxy, width, height)
+            if bbox is None:
+                continue
+            score = float(np.max(logit_vec))
+            clip_score = self._clip_score(image_source, bbox) if self._support_examples else None
+            ranking_score = clip_score if clip_score is not None else score
+            instances.append((ranking_score, score, clip_score, bbox, mask_bool, phrase, area_ratio))
+
+        if not instances:
+            return []
+
+        instances.sort(key=lambda item: item[0], reverse=True)
+        if self.config.top_k:
+            instances = instances[: self.config.top_k]
+
+        created_instances: list[AutoLabelInstance] = []
+        for local_index, instance in enumerate(instances):
+            ranking_score, score, clip_score, bbox, mask_bool, phrase, area_ratio = instance
+            if clip_score is not None and clip_score < self.config.clip_threshold:
+                continue
+            instance_dir = output_dir / f"instance_{local_index:02d}"
+            instance_dir.mkdir(parents=True, exist_ok=True)
+
+            overlay_path = instance_dir / "overlay.png"
+            mask_path = instance_dir / "mask.png"
+            crop_path = instance_dir / "bbox.png"
+            metadata_path = instance_dir / "report.json"
+
+            overlay_image = self._draw_overlay(
+                image_source,
+                np.asarray([[bbox[0], bbox[1], bbox[2], bbox[3]]], dtype=np.float32),
+                [mask_bool.astype(np.uint8)],
+            )
+            cv2.imwrite(str(overlay_path), overlay_image)
+
+            self._save_mask(mask_bool, mask_path)
+            crop_image = image_source[bbox[1] : bbox[3], bbox[0] : bbox[2]]
+            if crop_image.size == 0:
+                crop_image = image_source[max(0, bbox[1]) : max(0, bbox[1] + 1), max(0, bbox[0]) : max(0, bbox[0] + 1)]
+            crop_bgr = cv2.cvtColor(crop_image, cv2.COLOR_RGB2BGR)
+            cv2.imwrite(str(crop_path), crop_bgr)
+
+            metadata = {
+                "score": score,
+                "clip_score": clip_score,
+                "bbox": bbox,
+                "phrase": phrase,
+                "area_ratio": area_ratio,
+                "mask": str(mask_path.relative_to(output_dir.parent)),
+                "overlay": str(overlay_path.relative_to(output_dir.parent)),
+                "crop": str(crop_path.relative_to(output_dir.parent)),
+            }
+            with metadata_path.open("w", encoding="utf-8") as fp:
+                json.dump(metadata, fp, ensure_ascii=False, indent=2)
+
+            created_instances.append(
+                AutoLabelInstance(
+                    index=local_index,
+                    score=score,
+                    phrase=phrase,
+                    bbox=bbox,
+                    area_ratio=area_ratio,
+                    overlay_path=overlay_path,
+                    mask_path=mask_path,
+                    crop_path=crop_path,
+                    metadata_path=metadata_path,
+                    clip_score=clip_score,
+                )
+            )
+
+        manifest_path = output_dir / "manifest.json"
+        with manifest_path.open("w", encoding="utf-8") as fp:
+            json.dump([self._instance_to_dict(instance) for instance in created_instances], fp, indent=2)
+
+        return created_instances
+
+    # ------------------------------------------------------------------
+    # Utility methods
+    # ------------------------------------------------------------------
+    def _clip_score(self, image_source: np.ndarray, bbox: List[int]) -> Optional[float]:
+        if not self._support_examples:
+            return None
+        self._ensure_clip()
+        assert self._clip_model is not None
+        assert self._clip_preprocess is not None
+
+        crop = image_source[bbox[1] : bbox[3], bbox[0] : bbox[2]]
+        if crop.size == 0:
+            return None
+        crop_pil = Image.fromarray(crop)
+        tensor = self._clip_preprocess(crop_pil).unsqueeze(0).to(self.device)
+        with torch.no_grad():
+            embedding = self._clip_model.encode_image(tensor)
+        embedding = torch.nn.functional.normalize(embedding, dim=-1)
+        scores = [torch.matmul(embedding, example.embedding.T) for example in self._support_examples]
+        stacked = torch.cat(scores, dim=-1)
+        max_score = float(stacked.max().item())
+        return max_score
+
+    @staticmethod
+    def _instance_to_dict(instance: AutoLabelInstance) -> dict:
+        return {
+            "index": instance.index,
+            "score": instance.score,
+            "clip_score": instance.clip_score,
+            "phrase": instance.phrase,
+            "bbox": instance.bbox,
+            "area_ratio": instance.area_ratio,
+            "overlay": instance.overlay_path.name,
+            "mask": instance.mask_path.name,
+            "crop": instance.crop_path.name,
+            "metadata": instance.metadata_path.name,
+        }
+
+    @staticmethod
+    def _sanitize_bbox(box_xyxy: np.ndarray, width: int, height: int) -> Optional[List[int]]:
+        x0 = int(np.clip(round(float(box_xyxy[0])), 0, width - 1))
+        y0 = int(np.clip(round(float(box_xyxy[1])), 0, height - 1))
+        x1 = int(np.clip(round(float(box_xyxy[2])), x0 + 1, width))
+        y1 = int(np.clip(round(float(box_xyxy[3])), y0 + 1, height))
+        if x1 <= x0 or y1 <= y0:
+            return None
+        return [x0, y0, x1, y1]
+
+    def _save_mask(self, mask: np.ndarray, path: Path) -> None:
+        rgba = np.zeros((*mask.shape, 4), dtype=np.uint8)
+        rgba[..., 0] = 220
+        rgba[..., 1] = 20
+        rgba[..., 2] = 60
+        rgba[..., 3] = np.where(mask, int(self.config.overlay_alpha * 255), 0)
+        bgra = rgba[..., [2, 1, 0, 3]]
+        cv2.imwrite(str(path), bgra)
+
+    def _draw_overlay(
+        self,
+        image: np.ndarray,
+        boxes: np.ndarray,
+        masks: List[np.ndarray] | np.ndarray,
+    ) -> np.ndarray:
+        overlay = image.copy()
+        if overlay.dtype != np.uint8:
+            overlay = (overlay * 255).astype(np.uint8)
+        overlay = cv2.cvtColor(overlay, cv2.COLOR_RGB2BGR)
+        color = np.array((220, 20, 60), dtype=np.float32)
+        for idx, box in enumerate(boxes):
+            x0, y0, x1, y1 = [int(round(v)) for v in box.tolist()]
+            cv2.rectangle(overlay, (x0, y0), (x1, y1), color.astype(np.uint8).tolist(), 2)
+            cv2.putText(
+                overlay,
+                f"instance#{idx}",
+                (x0, max(y0 - 10, 10)),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.6,
+                color.astype(np.uint8).tolist(),
+                2,
+                cv2.LINE_AA,
+            )
+            mask = masks[idx]
+            if mask.ndim == 3:
+                mask = mask[0]
+            mask_bool = mask.astype(bool)
+            blended = overlay[mask_bool].astype(np.float32) * (1 - self.config.overlay_alpha) + color * self.config.overlay_alpha
+            overlay[mask_bool] = blended.astype(np.uint8)
+        return overlay


### PR DESCRIPTION
## Summary
- add an AutoLabeler pipeline that chains GroundingDINO detections with SAM2 masks and optional CLIP-based few-shot filtering
- provide a CLI entry point and documentation showing how to run the auto-labeling workflow and prepare support manifests

## Testing
- python -m compileall autodetector

------
https://chatgpt.com/codex/tasks/task_e_68db9c0b2378832f9190c4878ea1dfa5